### PR TITLE
Fix launcher arguments quoting

### DIFF
--- a/StartWebsiteBuilder.py
+++ b/StartWebsiteBuilder.py
@@ -115,7 +115,7 @@ def ensure_windows_shortcut(python_path: str) -> None:
         "$shell = New-Object -ComObject WScript.Shell",
         "$shortcut = $shell.CreateShortcut('{shortcut}')",
         "$shortcut.TargetPath = '{python_exe}'",
-        "$shortcut.Arguments = '"{script}"'",
+        "$shortcut.Arguments = '\"{script}\"'",
         "$shortcut.WorkingDirectory = '{working_dir}'",
         "$shortcut.WindowStyle = 1",
         "$shortcut.Description = 'Start Codex Website Builder'",


### PR DESCRIPTION
## Summary
- fix the PowerShell shortcut arguments string so the launcher script parses correctly

## Testing
- python StartWebsiteBuilder.py

------
https://chatgpt.com/codex/tasks/task_e_68cea47453388320bb37fc7d03bcfa77