### PR TITLE
Fix desktop dev startup wait endpoints

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,7 +6,7 @@
   "type": "commonjs",
   "scripts": {
     "dev": "cross-env CODEX_SKIP_EMBED=1 concurrently \"npm run dev --workspace server\" \"npm run dev --workspace web\" \"npm run start:dev\"",
-    "start:dev": "wait-on http://localhost:5173 http://localhost:8787 && cross-env NODE_ENV=development electron .",
+    "start:dev": "wait-on http-get://localhost:5173 http-get://localhost:8787/api/health && cross-env NODE_ENV=development electron .",
     "start": "cross-env NODE_ENV=production electron .",
     "prepare:assets": "node scripts/prepare.js",
     "build": "npm run build --workspace web && npm run build --workspace server && npm run prepare:assets",


### PR DESCRIPTION
## Summary
- update the desktop dev start script to wait for the web UI and server health endpoints before launching Electron so the app window opens once the services are ready

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cedb9c0f8c83209cfb289f76d05d1a