### PR TITLE
Add patch review controls and automate CLI login prompts

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,7 +6,7 @@
   "type": "commonjs",
   "scripts": {
     "dev": "cross-env CODEX_SKIP_EMBED=1 concurrently \"npm run dev --workspace server\" \"npm run dev --workspace web\" \"npm run start:dev\"",
-    "start:dev": "wait-on http://localhost:5173 http://localhost:8787 && cross-env NODE_ENV=development electron .",
+    "start:dev": "wait-on http-get://localhost:5173 http-get://localhost:8787/api/health && cross-env NODE_ENV=development electron .",
     "start": "cross-env NODE_ENV=production electron .",
     "prepare:assets": "node scripts/prepare.js",
     "build": "npm run build --workspace web && npm run build --workspace server && npm run prepare:assets",

--- a/apps/web/src/components/ChangeFeed.tsx
+++ b/apps/web/src/components/ChangeFeed.tsx
@@ -1,12 +1,21 @@
 import * as Tabs from "@radix-ui/react-tabs";
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import useEditorStore from "../state/useEditorStore";
 import { useTranslation } from "../hooks/useTranslation";
+import { applyPatch, rejectPatch, revertPatch } from "../services/api";
+import type { PatchEvent } from "../types";
 
 const levelStyles: Record<string, string> = {
   info: "bg-slate-800/70 text-slate-200",
   warning: "bg-amber-500/20 text-amber-200",
   error: "bg-rose-500/20 text-rose-200"
+};
+
+const statusStyles: Record<PatchEvent["status"], string> = {
+  pending: "bg-blue-500/10 text-blue-200",
+  applied: "bg-emerald-500/15 text-emerald-200",
+  discarded: "bg-rose-500/15 text-rose-200",
+  reverted: "bg-slate-500/20 text-slate-100"
 };
 
 function DiffPreview({ diff }: { diff: string }) {
@@ -21,8 +30,50 @@ function DiffPreview({ diff }: { diff: string }) {
 export function ChangeFeed() {
   const patches = useEditorStore((state) => state.patches);
   const logs = useEditorStore((state) => state.logs);
+  const appendLog = useEditorStore((state) => state.appendLog);
   const translation = useTranslation();
   const { changeFeed } = translation;
+
+  const [pendingActions, setPendingActions] = useState<Record<string, boolean>>({});
+
+  const runPatchAction = useCallback(
+    async (patch: PatchEvent, action: () => Promise<void>) => {
+      setPendingActions((state) => ({ ...state, [patch.id]: true }));
+      try {
+        await action();
+      } catch (error) {
+        appendLog({ level: "error", message: `${changeFeed.actionError}: ${(error as Error).message}` });
+      } finally {
+        setPendingActions((state) => {
+          const next = { ...state };
+          delete next[patch.id];
+          return next;
+        });
+      }
+    },
+    [appendLog, changeFeed.actionError]
+  );
+
+  const handleApply = useCallback(
+    async (patch: PatchEvent) => {
+      await runPatchAction(patch, () => applyPatch(patch.id));
+    },
+    [runPatchAction]
+  );
+
+  const handleReject = useCallback(
+    async (patch: PatchEvent) => {
+      await runPatchAction(patch, () => rejectPatch(patch.id));
+    },
+    [runPatchAction]
+  );
+
+  const handleRevert = useCallback(
+    async (patch: PatchEvent) => {
+      await runPatchAction(patch, () => revertPatch(patch.id));
+    },
+    [runPatchAction]
+  );
 
   return (
     <section
@@ -50,16 +101,67 @@ export function ChangeFeed() {
             <p className="text-xs text-slate-500">{changeFeed.emptyPatches}</p>
           ) : (
             <div className="flex flex-col gap-3">
-              {patches.map((patch) => (
-                <article key={patch.id} className="rounded-xl border border-white/5 bg-slate-950/70 p-3 text-sm text-slate-100">
-                  <div className="mb-2 flex items-center justify-between text-xs text-slate-400">
-                    <span>{patch.file}</span>
-                    <span>{new Date(patch.createdAt).toLocaleTimeString()}</span>
-                  </div>
-                  {patch.note && <p className="text-xs text-slate-300">{patch.note}</p>}
-                  <DiffPreview diff={patch.diff} />
-                </article>
-              ))}
+              {patches.map((patch) => {
+                const busy = pendingActions[patch.id] ?? false;
+                const showApply = patch.status === "pending" || patch.status === "discarded" || patch.status === "reverted";
+                return (
+                  <article key={patch.id} className="rounded-xl border border-white/5 bg-slate-950/70 p-3 text-sm text-slate-100">
+                    <div className="mb-2 flex flex-wrap items-center justify-between gap-2 text-xs text-slate-400">
+                      <div className="flex items-center gap-2">
+                        <span>{patch.file}</span>
+                        <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${statusStyles[patch.status]}`}>
+                          {changeFeed.statusLabel[patch.status]}
+                        </span>
+                      </div>
+                      <span>{new Date((patch.resolvedAt ?? patch.createdAt)).toLocaleTimeString()}</span>
+                    </div>
+                    {patch.note && <p className="text-xs text-slate-300">{patch.note}</p>}
+                    <DiffPreview diff={patch.diff} />
+                    <div className="mt-3 flex flex-wrap gap-2 text-xs">
+                      {showApply && (
+                        <button
+                          type="button"
+                          onClick={() => void handleApply(patch)}
+                          disabled={busy}
+                          className="inline-flex items-center justify-center rounded-lg bg-emerald-500/20 px-3 py-1 font-semibold text-emerald-100 transition hover:bg-emerald-500/25 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          {busy ? changeFeed.actions.working : patch.status === "pending" ? changeFeed.actions.apply : changeFeed.actions.reapply}
+                        </button>
+                      )}
+                      {patch.status === "pending" && (
+                        <button
+                          type="button"
+                          onClick={() => void handleReject(patch)}
+                          disabled={busy}
+                          className="inline-flex items-center justify-center rounded-lg bg-rose-500/20 px-3 py-1 font-semibold text-rose-100 transition hover:bg-rose-500/25 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          {busy ? changeFeed.actions.working : changeFeed.actions.reject}
+                        </button>
+                      )}
+                      {patch.status === "applied" && (
+                        <button
+                          type="button"
+                          onClick={() => void handleRevert(patch)}
+                          disabled={busy}
+                          className="inline-flex items-center justify-center rounded-lg bg-amber-500/20 px-3 py-1 font-semibold text-amber-100 transition hover:bg-amber-500/25 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          {busy ? changeFeed.actions.working : changeFeed.actions.revert}
+                        </button>
+                      )}
+                      {patch.status === "reverted" && (
+                        <button
+                          type="button"
+                          onClick={() => void handleReject(patch)}
+                          disabled={busy}
+                          className="inline-flex items-center justify-center rounded-lg bg-slate-700/40 px-3 py-1 font-semibold text-slate-200 transition hover:bg-slate-700/60 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          {busy ? changeFeed.actions.working : changeFeed.actions.reject}
+                        </button>
+                      )}
+                    </div>
+                  </article>
+                );
+              })}
             </div>
           )}
         </Tabs.Content>

--- a/apps/web/src/components/OpenAIConnectCard.tsx
+++ b/apps/web/src/components/OpenAIConnectCard.tsx
@@ -13,7 +13,7 @@ export function OpenAIConnectCard() {
   const [isDisconnecting, setIsDisconnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const docsUrl = "https://platform.openai.com/docs/guides/cli";
+  const docsUrl = "https://platform.openai.com/docs/guides/openai-cli";
   const hasConnection = openAiStatus.connected;
   const connectionLabel = hasConnection
     ? openAi.statusConnected(openAiStatus.label ?? openAi.statusMasked(openAiStatus.maskedKey ?? "••••"))

--- a/apps/web/src/data/translations.ts
+++ b/apps/web/src/data/translations.ts
@@ -1,4 +1,4 @@
-import type { TaskStatus } from "../types";
+import type { PatchStatus, TaskStatus } from "../types";
 
 export type Language = "en" | "de";
 
@@ -90,6 +90,15 @@ interface Translation {
     emptyPatches: string;
     emptyLogs: string;
     logLevelLabel: Record<"info" | "warning" | "error", string>;
+    statusLabel: Record<PatchStatus, string>;
+    actions: {
+      apply: string;
+      reapply: string;
+      reject: string;
+      revert: string;
+      working: string;
+    };
+    actionError: string;
   };
   tutorial: TutorialCopy;
   openAi: {
@@ -184,7 +193,21 @@ export const translations: Record<Language, Translation> = {
         info: "Info",
         warning: "Warning",
         error: "Error"
-      }
+      },
+      statusLabel: {
+        pending: "Pending",
+        applied: "Applied",
+        discarded: "Discarded",
+        reverted: "Reverted"
+      },
+      actions: {
+        apply: "Apply patch",
+        reapply: "Apply again",
+        reject: "Reject",
+        revert: "Revert",
+        working: "Working…"
+      },
+      actionError: "Failed to update patch"
     },
     tutorial: {
       card: {
@@ -372,7 +395,21 @@ export const translations: Record<Language, Translation> = {
         info: "Info",
         warning: "Warnung",
         error: "Fehler"
-      }
+      },
+      statusLabel: {
+        pending: "Offen",
+        applied: "Übernommen",
+        discarded: "Verworfen",
+        reverted: "Zurückgesetzt"
+      },
+      actions: {
+        apply: "Patch übernehmen",
+        reapply: "Erneut übernehmen",
+        reject: "Ablehnen",
+        revert: "Rückgängig machen",
+        working: "Arbeite…"
+      },
+      actionError: "Patch-Aktion fehlgeschlagen"
     },
     tutorial: {
       card: {

--- a/apps/web/src/hooks/useServerConnection.ts
+++ b/apps/web/src/hooks/useServerConnection.ts
@@ -8,7 +8,8 @@ export function useServerConnection() {
   const setRepositoryPath = useEditorStore((state) => state.setRepositoryPath);
   const upsertTask = useEditorStore((state) => state.upsertTask);
   const resetTasks = useEditorStore((state) => state.resetTasks);
-  const pushPatch = useEditorStore((state) => state.pushPatch);
+  const setPatches = useEditorStore((state) => state.setPatches);
+  const upsertPatch = useEditorStore((state) => state.upsertPatch);
   const appendLog = useEditorStore((state) => state.appendLog);
   const setWebsocketReady = useEditorStore((state) => state.setWebsocketReady);
 
@@ -45,12 +46,23 @@ export function useServerConnection() {
             upsertTask(payload.task);
             break;
           case "patch":
-            pushPatch(payload.patch);
+            upsertPatch(payload.patch);
             appendLog({
               level: "info",
               message: `Patch generated for ${payload.patch.file}`,
               createdAt: payload.patch.createdAt
             });
+            break;
+          case "patch:updated":
+            upsertPatch(payload.patch);
+            appendLog({
+              level: "info",
+              message: `Patch ${payload.patch.status} → ${payload.patch.file}`,
+              createdAt: payload.patch.resolvedAt ?? Date.now()
+            });
+            break;
+          case "patch:bootstrap":
+            setPatches(payload.patches);
             break;
           case "workspace:file":
             appendLog({
@@ -67,5 +79,5 @@ export function useServerConnection() {
     return () => {
       socket.close();
     };
-  }, [appendLog, pushPatch, resetTasks, serverUrl, setRepositoryPath, setWebsocketReady, upsertTask, wsUrl]);
+  }, [appendLog, resetTasks, serverUrl, setPatches, setRepositoryPath, setWebsocketReady, upsertPatch, upsertTask, wsUrl]);
 }

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -1,4 +1,4 @@
-import type { GitStatusSummary, OpenAiStatus, Task } from "../types";
+import type { GitStatusSummary, OpenAiStatus, PatchEvent, Task } from "../types";
 import useEditorStore from "../state/useEditorStore";
 
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
@@ -59,4 +59,16 @@ export async function disconnectOpenAi() {
   return request<OpenAiStatus>("/api/settings/openai", {
     method: "DELETE"
   });
+}
+
+export async function applyPatch(patchId: string) {
+  return request<PatchEvent>(`/api/patches/${patchId}/apply`, { method: "POST" });
+}
+
+export async function rejectPatch(patchId: string) {
+  return request<PatchEvent>(`/api/patches/${patchId}/reject`, { method: "POST" });
+}
+
+export async function revertPatch(patchId: string) {
+  return request<PatchEvent>(`/api/patches/${patchId}/revert`, { method: "POST" });
 }

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -11,6 +11,8 @@ export interface Task {
   error?: string;
 }
 
+export type PatchStatus = "pending" | "applied" | "discarded" | "reverted";
+
 export interface PatchEvent {
   id: string;
   taskId: string;
@@ -18,6 +20,9 @@ export interface PatchEvent {
   diff: string;
   note?: string;
   createdAt: number;
+  status: PatchStatus;
+  resolvedAt: number | null;
+  appliedAt: number | null;
 }
 
 export type WorkspaceFileChange = "add" | "change" | "unlink";
@@ -26,6 +31,8 @@ export type ServerEvent =
   | { type: "task:created"; task: Task }
   | { type: "task:updated"; task: Task }
   | { type: "patch"; patch: PatchEvent }
+  | { type: "patch:updated"; patch: PatchEvent }
+  | { type: "patch:bootstrap"; patches: PatchEvent[] }
   | { type: "workspace:file"; path: string; change: WorkspaceFileChange }
   | { type: "workspace:ready"; repository: string }
   | { type: "task:bootstrap"; tasks: Task[] };


### PR DESCRIPTION
## Summary
- add interactive login automation so the OpenAI CLI is launched with auto-confirmed prompts and better error handling
- persist generated patches on the server, expose apply/reject/revert endpoints, and broadcast updates to new websocket clients
- surface granular patch controls in the UI with new translations, store helpers, and API calls so users can accept, reject, or revert Codex changes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cedb9c0f8c83209cfb289f76d05d1a