### PR TITLE
Support Codex CLI login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ npm run dev:desktop
 * Wenn dein Projekt einen Dev‑Server hat (z. B. Vite/Next): URL eintragen (z. B. [http://localhost:3000](http://localhost:3000)).
 * Für statische Sites: Build‑Ordner (z. B. `dist/`) angeben.
 
-**GPT-Account verknüpfen:** In der rechten Spalte findest du die Karte **„Codex mit GPT verbinden“**. Ein Klick auf **„Mit GPT anmelden“** startet `openai login` direkt aus der App, öffnet den offiziellen Browser-Flow und speichert den Token ausschließlich in deinem Codex-Profil (`%APPDATA%/…` bzw. `~/Library/Application Support/`). Du kannst die Verbindung jederzeit neu herstellen oder trennen – der Token verlässt nie deinen Rechner.
+**GPT-Account verknüpfen:** In der rechten Spalte findest du die Karte **„Codex mit GPT verbinden“**. Ein Klick auf **„Mit GPT anmelden“** startet automatisch die installierte OpenAI- oder Codex-CLI (z. B. `openai login` oder `codex login`), öffnet den offiziellen Browser-Flow und speichert den Token ausschließlich in deinem Codex-Profil (`%APPDATA%/…` bzw. `~/Library/Application Support/`). Du kannst die Verbindung jederzeit neu herstellen oder trennen – der Token verlässt nie deinen Rechner.
 
 **Alternative ohne CLI:** Direkt unter den Buttons kannst du einen bestehenden API-Schlüssel einfügen und speichern. Die App übernimmt den Wert in dein lokales Codex-Profil, falls der CLI-Login nicht verfügbar ist.
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@openai/codex": "^0.39.0",
     "body-parser": "^1.20.3",
     "chokidar": "^3.6.0",
     "cors": "^2.8.5",
@@ -17,19 +18,19 @@
     "express": "^4.21.2",
     "openai": "^4.76.1",
     "simple-git": "^3.27.0",
-    "ws": "^8.18.0",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.35.0",
     "@types/body-parser": "^1.19.5",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/node": "^22.10.1",
     "@types/ws": "^8.5.10",
-    "@eslint/js": "^9.35.0",
     "eslint": "^9.35.0",
+    "tsx": "^4.19.2",
     "typescript": "~5.8.3",
-    "typescript-eslint": "^8.43.0",
-    "tsx": "^4.19.2"
+    "typescript-eslint": "^8.43.0"
   }
 }

--- a/apps/web/src/components/OpenAIConnectCard.tsx
+++ b/apps/web/src/components/OpenAIConnectCard.tsx
@@ -15,7 +15,7 @@ export function OpenAIConnectCard() {
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const docsUrl = "https://platform.openai.com/docs/guides/openai-cli";
+  const docsUrl = "https://github.com/openai/codex#readme";
   const hasConnection = openAiStatus.connected;
 
   const formatStatusMessage = (status = openAiStatus) => {
@@ -117,7 +117,9 @@ export function OpenAIConnectCard() {
           {connectionLabel}
         </div>
         {hasConnection && openAiStatus.method === "cli" && (
-          <p className="text-xs text-slate-400">{openAi.cliProfile(openAiStatus.profile ?? "default")}</p>
+          <p className="text-xs text-slate-400">
+            {openAi.cliProfile(openAiStatus.cliVariant ?? "openai", openAiStatus.profile ?? "default")}
+          </p>
         )}
         {error && <p className="text-xs text-rose-300">{error}</p>}
         <div className="flex flex-col gap-3">

--- a/apps/web/src/data/translations.ts
+++ b/apps/web/src/data/translations.ts
@@ -124,7 +124,7 @@ interface Translation {
     statusMasked: (masked: string) => string;
     statusManual: (masked: string) => string;
     statusMissing: string;
-    cliProfile: (profile: string) => string;
+    cliProfile: (variant: "openai" | "codex", profile: string) => string;
   };
   deployPanel: {
     title: string;
@@ -310,7 +310,7 @@ export const translations: Record<Language, Translation> = {
     openAi: {
       title: "Connect Codex to GPT",
       description:
-        "Sign in once with the OpenAI CLI. Codex stores the token locally and reuses it for your coding sessions.",
+        "Sign in once with the OpenAI or Codex CLI. Codex stores the token locally and reuses it for your coding sessions.",
       helper: "The login command runs locally; no credentials ever leave your machine.",
       docsLabel: "Open CLI guide",
       login: "Sign in with GPT",
@@ -319,7 +319,8 @@ export const translations: Record<Language, Translation> = {
       disconnect: "Disconnect",
       disconnecting: "Disconnecting…",
       loginHint: "A browser window opens with the official OpenAI login flow.",
-      loginDetails: "After finishing the flow the CLI stores a short-lived API key in ~/.config/openai/config.yaml.",
+      loginDetails:
+        "The OpenAI CLI stores the key in ~/.config/openai/config.yaml, the Codex CLI writes credentials to ~/.codex/auth.json.",
       manualLabel: "Paste an API key manually",
       manualHint: "Create or reuse an API key on platform.openai.com and paste it here if the CLI login is unavailable.",
       manualPlaceholder: "sk-...",
@@ -331,7 +332,8 @@ export const translations: Record<Language, Translation> = {
       statusMasked: (masked: string) => `Token ${masked}`,
       statusManual: (masked: string) => `Manual key ${masked}`,
       statusMissing: "Not connected yet",
-      cliProfile: (profile: string) => `Linked via OpenAI CLI profile “${profile}”`
+      cliProfile: (variant, profile) =>
+        variant === "codex" ? "Signed in via Codex CLI credentials" : `Linked via OpenAI CLI profile “${profile}”`
     },
     deployPanel: {
       title: "Deploy",
@@ -518,7 +520,8 @@ export const translations: Record<Language, Translation> = {
     },
     openAi: {
       title: "Codex mit GPT verbinden",
-      description: "Melde dich einmal über die OpenAI-CLI an. Codex speichert den Token lokal und nutzt ihn für deine Sessions.",
+      description:
+        "Melde dich einmal über die OpenAI- oder Codex-CLI an. Codex speichert den Token lokal und nutzt ihn für deine Sessions.",
       helper: "Der Login läuft komplett lokal – der Token bleibt auf deinem Rechner.",
       docsLabel: "CLI-Anleitung öffnen",
       login: "Mit GPT anmelden",
@@ -527,7 +530,8 @@ export const translations: Record<Language, Translation> = {
       disconnect: "Verbindung trennen",
       disconnecting: "Trenne…",
       loginHint: "Wir öffnen das offizielle OpenAI-Login im Browser.",
-      loginDetails: "Nach Abschluss legt die CLI den Schlüssel unter ~/.config/openai/config.yaml ab.",
+      loginDetails:
+        "Die OpenAI-CLI legt den Schlüssel unter ~/.config/openai/config.yaml ab, die Codex-CLI speichert ihn in ~/.codex/auth.json.",
       manualLabel: "API-Schlüssel direkt eintragen",
       manualHint: "Falls der CLI-Login nicht klappt: Erzeuge auf platform.openai.com einen API-Schlüssel und füge ihn hier ein.",
       manualPlaceholder: "sk-...",
@@ -539,7 +543,10 @@ export const translations: Record<Language, Translation> = {
       statusMasked: (masked: string) => `Token ${masked}`,
       statusManual: (masked: string) => `Eigener Schlüssel ${masked}`,
       statusMissing: "Noch nicht verbunden",
-      cliProfile: (profile: string) => `Gekoppelt über CLI-Profil „${profile}“`
+      cliProfile: (variant, profile) =>
+        variant === "codex"
+          ? "Angemeldet über die Codex-CLI-Anmeldedaten"
+          : `Gekoppelt über OpenAI-CLI-Profil „${profile}“`
     },
     deployPanel: {
       title: "Deploy",

--- a/apps/web/src/state/useEditorStore.ts
+++ b/apps/web/src/state/useEditorStore.ts
@@ -72,7 +72,15 @@ export const useEditorStore = create<EditorState>((set) => ({
   isPickerActive: false,
   previewHtml: samplePreviewHtml,
   websocketReady: false,
-  openAiStatus: { connected: false, method: null, label: null, maskedKey: null, profile: null, updatedAt: null },
+  openAiStatus: {
+    connected: false,
+    method: null,
+    label: null,
+    maskedKey: null,
+    profile: null,
+    cliVariant: null,
+    updatedAt: null
+  },
   tutorialVisible: false,
   tutorialStep: 0,
   tutorialCompleted: storedTutorialState === "completed",

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -59,5 +59,6 @@ export interface OpenAiStatus {
   label: string | null;
   maskedKey: string | null;
   profile: string | null;
+  cliVariant: "openai" | "codex" | null;
   updatedAt: number | null;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
     "apps/server": {
       "version": "0.0.0",
       "dependencies": {
+        "@openai/codex": "^0.39.0",
         "body-parser": "^1.20.3",
         "chokidar": "^3.6.0",
         "cors": "^2.8.5",
@@ -1874,6 +1875,21 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/@openai/codex": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.39.0.tgz",
+      "integrity": "sha512-UEcswDFZ9dwmMWuZlECff3CDTj1lEVO3Vm3mqqJrY7azLMIa2PLmC2+qHkF94RIQBD8/tkgAmKxiSnUQMr8Lgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vscode/ripgrep": "^1.15.14"
+      },
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3369,6 +3385,18 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vscode/ripgrep": {
+      "version": "1.15.14",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.15.14.tgz",
+      "integrity": "sha512-/G1UJPYlm+trBWQ6cMO3sv6b8D1+G16WaJH1/DSqw32JOVlzgZbLkDxRyzIpTpv30AcYGMkCf5tUqGlW6HbDWw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "https-proxy-agent": "^7.0.2",
+        "proxy-from-env": "^1.1.0",
+        "yauzl": "^2.9.2"
+      }
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
@@ -3445,7 +3473,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -4147,7 +4174,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -6102,7 +6128,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -6886,7 +6911,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -8634,7 +8658,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -8877,7 +8900,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pump": {
@@ -10974,7 +10996,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",


### PR DESCRIPTION
## Summary
- add the @openai/codex dependency and resolve either OpenAI or Codex CLIs when performing the GPT login
- extract API keys from codex auth.json files, store the CLI variant in metadata, and expose it in the web UI
- refresh UI copy and README instructions to mention Codex CLI support for logging in

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfa46c472c83208a7ce2a994d1fa82